### PR TITLE
Allow accepting assist suggestions directly

### DIFF
--- a/src/sim/game.rs
+++ b/src/sim/game.rs
@@ -1,11 +1,14 @@
 use super::data_storage::DataStorage;
 use super::economy;
 use super::jobs::{self, Job};
-use super::processors::{AssignmentError, CompletedJob, ProcessorState};
+use super::processors::{
+    AssignmentError, CompletedJob, DaemonMode, JobEvaluation, ProcessorEvent, ProcessorState,
+};
 use rand::Rng;
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::time::Duration;
 use thiserror::Error;
@@ -16,6 +19,14 @@ const JOB_SPAWN_INTERVAL: Duration = Duration::from_secs(6);
 const DAY_DURATION: Duration = Duration::from_secs(18);
 pub const DAEMON_UNLOCK_CREDITS: u64 = 500;
 
+#[derive(Debug, Clone)]
+pub struct AssistSuggestion {
+    pub job_index: usize,
+    pub eta_secs: f64,
+    pub reliability: f64,
+    pub heat: f64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameState {
     pub credits: u64,
@@ -24,6 +35,8 @@ pub struct GameState {
     pub storage: DataStorage,
     pub daemon_unlocked: bool,
     pub daemon_enabled: bool,
+    #[serde(default)]
+    pub thermal_paste_timer_ms: u64,
     pub job_counter: u64,
     #[serde(default = "default_unlocked_tags")]
     pub unlocked_tags: Vec<String>,
@@ -48,6 +61,7 @@ impl Default for GameState {
             storage: DataStorage::new(120),
             daemon_unlocked: false,
             daemon_enabled: false,
+            thermal_paste_timer_ms: 0,
             job_counter: 0,
             unlocked_tags: default_unlocked_tags(),
             store_purchases: default_store_purchases(),
@@ -72,6 +86,7 @@ impl Game {
         if state.store_purchases.len() < STORE_ITEMS.len() {
             state.store_purchases.resize(STORE_ITEMS.len(), 0);
         }
+        state.daemon_enabled = false;
         if state.unlocked_tags.is_empty() {
             state.unlocked_tags = default_unlocked_tags();
         }
@@ -83,6 +98,13 @@ impl Game {
             state.unlocked_tags.insert(0, jobs::GENERAL_TAG.to_string());
         }
         for processor in &mut state.processors {
+            processor.ensure_runtime_defaults();
+            if state.daemon_unlocked {
+                processor.daemon_unlocked = true;
+            }
+            if state.daemon_enabled && processor.daemon_mode == DaemonMode::Off {
+                processor.daemon_mode = DaemonMode::Auto;
+            }
             for tag in &state.unlocked_tags {
                 if !processor.supports(tag) {
                     processor.instruction_set.push(tag.clone());
@@ -112,14 +134,31 @@ impl Game {
         }
 
         self.tick_processors(delta);
-        if !self.state.daemon_unlocked && self.state.credits >= DAEMON_UNLOCK_CREDITS {
-            self.state.daemon_unlocked = true;
-            self.push_message("Daemon automation unlocked. Press D to toggle.".to_string());
+
+        if self.state.thermal_paste_timer_ms > 0 {
+            let delta_ms = delta.as_millis() as u64;
+            if delta_ms > 0 {
+                if delta_ms >= self.state.thermal_paste_timer_ms {
+                    self.state.thermal_paste_timer_ms = 0;
+                    self.push_message("Thermal paste bonus has dissipated.".to_string());
+                } else {
+                    self.state.thermal_paste_timer_ms -= delta_ms;
+                }
+            }
         }
 
-        if self.state.daemon_enabled {
-            self.try_daemon_assignment();
+        if !self.state.daemon_unlocked && self.state.credits >= DAEMON_UNLOCK_CREDITS {
+            self.state.daemon_unlocked = true;
+            for processor in &mut self.state.processors {
+                processor.daemon_unlocked = true;
+            }
+            self.push_message(
+                "Daemon automation unlocked. Focus a processor and press D to cycle modes."
+                    .to_string(),
+            );
         }
+
+        self.try_daemon_assignment();
     }
 
     pub fn take_job(&mut self, index: usize) -> Option<Job> {
@@ -159,14 +198,22 @@ impl Game {
             if !processor.supports(&job_tag) {
                 return Err(AssignmentError::IncompatibleInstruction(job_tag));
             }
-            duration_ms = economy::assignment_duration_ms(&job, processor, daemon);
-            processor.assign(job, duration_ms, daemon);
+            if !processor.is_functional() {
+                return Err(AssignmentError::ProcessorInoperative);
+            }
+            let penalty = if daemon {
+                Some(processor.daemon_penalty.clone())
+            } else {
+                None
+            };
+            duration_ms = economy::assignment_duration_ms(&job, processor, penalty.as_ref());
+            processor.assign(job, duration_ms, penalty);
             processor_name = processor.name.clone();
         }
         let seconds = duration_ms as f64 / 1000.0;
         if daemon {
             self.push_message(format!(
-                "Daemon queued {job_name} on {processor_name} ({seconds:.1}s, -quality)",
+                "Daemon queued {job_name} on {processor_name} ({seconds:.1}s, automation tax)",
             ));
         } else {
             self.push_message(format!(
@@ -174,20 +221,6 @@ impl Game {
             ));
         }
         Ok(())
-    }
-
-    pub fn toggle_daemon(&mut self) -> bool {
-        if self.state.daemon_unlocked {
-            self.state.daemon_enabled = !self.state.daemon_enabled;
-            if self.state.daemon_enabled {
-                self.push_message("Daemon enabled: idle processors will self-assign.".to_string());
-            } else {
-                self.push_message("Daemon disabled.".to_string());
-            }
-            true
-        } else {
-            false
-        }
     }
 
     pub fn job_spawn_progress(&self) -> f64 {
@@ -214,22 +247,61 @@ impl Game {
         &STORE_ITEMS
     }
 
-    pub fn item_cost(&self, index: usize) -> Option<u64> {
+    pub fn item_cost(&self, index: usize, processor_index: Option<usize>) -> Option<u64> {
         let item = STORE_ITEMS.get(index)?;
-        let purchases = *self.state.store_purchases.get(index).unwrap_or(&0);
-        if let Some(max) = item.max_purchases {
-            if purchases >= max {
-                return None;
+        match item.action {
+            StoreAction::ReplaceProcessor => {
+                let processor = processor_index.and_then(|idx| self.state.processors.get(idx))?;
+                let cost = replacement_cost_for_processor(processor);
+                if cost == 0 { None } else { Some(cost) }
+            }
+            StoreAction::ReplaceModel => {
+                let processor = processor_index.and_then(|idx| self.state.processors.get(idx))?;
+                let cost = self.replacement_cost_for_model(&processor.name);
+                if cost == 0 { None } else { Some(cost) }
+            }
+            StoreAction::UpgradeCooling => {
+                let processor = processor_index.and_then(|idx| self.state.processors.get(idx))?;
+                if processor.cooling_level >= processor.cooling_cap {
+                    return None;
+                }
+                Some(item.base_cost + item.cost_step * processor.cooling_level as u64)
+            }
+            StoreAction::UpgradeHardening => {
+                let processor = processor_index.and_then(|idx| self.state.processors.get(idx))?;
+                if processor.hardening_level >= 3 {
+                    return None;
+                }
+                Some(item.base_cost + item.cost_step * processor.hardening_level as u64)
+            }
+            StoreAction::InstallDaemonFirmware => {
+                let processor = processor_index.and_then(|idx| self.state.processors.get(idx))?;
+                if processor.daemon_unlocked {
+                    return None;
+                }
+                Some(item.base_cost + item.cost_step * processor.daemon_priority.max(0) as u64)
+            }
+            _ => {
+                let purchases = *self.state.store_purchases.get(index).unwrap_or(&0);
+                if let Some(max) = item.max_purchases {
+                    if purchases >= max {
+                        return None;
+                    }
+                }
+                Some(item.base_cost + item.cost_step * purchases as u64)
             }
         }
-        Some(item.base_cost + item.cost_step * purchases as u64)
     }
 
     pub fn store_purchases(&self, index: usize) -> Option<u32> {
         self.state.store_purchases.get(index).copied()
     }
 
-    pub fn purchase_item(&mut self, index: usize) -> Result<(), PurchaseError> {
+    pub fn purchase_item(
+        &mut self,
+        index: usize,
+        processor_index: Option<usize>,
+    ) -> Result<(), PurchaseError> {
         let item = STORE_ITEMS.get(index).ok_or(PurchaseError::InvalidItem)?;
         let purchases = *self.state.store_purchases.get(index).unwrap_or(&0);
         if let Some(max) = item.max_purchases {
@@ -237,14 +309,69 @@ impl Game {
                 return Err(PurchaseError::MaxedOut { item: item.name });
             }
         }
-        if let StoreAction::UnlockInstructionSet { tag } = item.action {
-            if self.is_instruction_unlocked(tag) {
-                return Err(PurchaseError::InstructionAlreadyUnlocked {
-                    tag: tag.to_string(),
-                });
+        match item.action {
+            StoreAction::ReplaceProcessor | StoreAction::ReplaceModel => {}
+            _ => {
+                if let StoreAction::UnlockInstructionSet { tag } = item.action {
+                    if self.is_instruction_unlocked(tag) {
+                        return Err(PurchaseError::InstructionAlreadyUnlocked {
+                            tag: tag.to_string(),
+                        });
+                    }
+                }
             }
         }
-        let cost = item.base_cost + item.cost_step * purchases as u64;
+        let cost = match item.action {
+            StoreAction::ReplaceProcessor => {
+                let processor = processor_index
+                    .and_then(|idx| self.state.processors.get(idx))
+                    .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                let cost = replacement_cost_for_processor(processor);
+                if cost == 0 {
+                    return Err(PurchaseError::ProcessorHealthy);
+                }
+                cost
+            }
+            StoreAction::ReplaceModel => {
+                let processor = processor_index
+                    .and_then(|idx| self.state.processors.get(idx))
+                    .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                let cost = self.replacement_cost_for_model(&processor.name);
+                if cost == 0 {
+                    return Err(PurchaseError::NoMatchingProcessors);
+                }
+                cost
+            }
+            StoreAction::UpgradeCooling => {
+                let processor = processor_index
+                    .and_then(|idx| self.state.processors.get(idx))
+                    .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                if processor.cooling_level >= processor.cooling_cap {
+                    return Err(PurchaseError::UpgradeAtCap);
+                }
+                item.base_cost + item.cost_step * processor.cooling_level as u64
+            }
+            StoreAction::UpgradeHardening => {
+                let processor = processor_index
+                    .and_then(|idx| self.state.processors.get(idx))
+                    .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                if processor.hardening_level >= 3 {
+                    return Err(PurchaseError::UpgradeAtCap);
+                }
+                item.base_cost + item.cost_step * processor.hardening_level as u64
+            }
+            StoreAction::InstallDaemonFirmware => {
+                let processor = processor_index
+                    .and_then(|idx| self.state.processors.get(idx))
+                    .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                if processor.daemon_unlocked {
+                    return Err(PurchaseError::DaemonAlreadyInstalled);
+                }
+                item.base_cost + item.cost_step * processor.daemon_priority.max(0) as u64
+            }
+            _ => item.base_cost + item.cost_step * purchases as u64,
+        };
+
         if self.state.credits < cost {
             return Err(PurchaseError::InsufficientCredits { cost });
         }
@@ -281,9 +408,98 @@ impl Game {
                     );
                 }
             }
+            StoreAction::UpgradeCooling => {
+                let (name, level) = {
+                    let processor = processor_index
+                        .and_then(|idx| self.state.processors.get_mut(idx))
+                        .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                    if processor.cooling_level >= processor.cooling_cap {
+                        return Err(PurchaseError::UpgradeAtCap);
+                    }
+                    processor.cooling_level += 1;
+                    processor.ensure_runtime_defaults();
+                    (processor.name.clone(), processor.cooling_level)
+                };
+                self.push_message(format!("{name} cooling upgraded to level {level}."));
+            }
+            StoreAction::UpgradeHardening => {
+                let (name, level) = {
+                    let processor = processor_index
+                        .and_then(|idx| self.state.processors.get_mut(idx))
+                        .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                    if processor.hardening_level >= 3 {
+                        return Err(PurchaseError::UpgradeAtCap);
+                    }
+                    processor.hardening_level += 1;
+                    (processor.name.clone(), processor.hardening_level)
+                };
+                self.push_message(format!("{name} hardening increased to level {level}."));
+            }
+            StoreAction::ApplyThermalPaste => {
+                self.state.thermal_paste_timer_ms = DAY_DURATION.as_millis() as u64;
+                self.push_message(
+                    "Thermal paste refreshed: cooling bonus active this cycle.".to_string(),
+                );
+            }
+            StoreAction::InstallDaemonFirmware => {
+                let name = {
+                    let processor = processor_index
+                        .and_then(|idx| self.state.processors.get_mut(idx))
+                        .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                    processor.daemon_unlocked = true;
+                    processor.daemon_penalty.quality = processor.daemon_penalty.quality.max(-3);
+                    processor.daemon_penalty.time_multiplier =
+                        (processor.daemon_penalty.time_multiplier - 0.02).max(1.02);
+                    processor.name.clone()
+                };
+                self.push_message(format!(
+                    "{name} daemon firmware installed. Automation penalties eased."
+                ));
+            }
+            StoreAction::ReplaceProcessor => {
+                let name = {
+                    let processor = processor_index
+                        .and_then(|idx| self.state.processors.get_mut(idx))
+                        .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                    if processor.is_functional() {
+                        return Err(PurchaseError::ProcessorHealthy);
+                    }
+                    processor.replace();
+                    processor.name.clone()
+                };
+                self.push_message(format!(
+                    "Replaced {name} chassis. Unit restored to service."
+                ));
+            }
+            StoreAction::ReplaceModel => {
+                let name = {
+                    let processor = processor_index
+                        .and_then(|idx| self.state.processors.get(idx))
+                        .ok_or(PurchaseError::ProcessorSelectionRequired)?;
+                    processor.name.clone()
+                };
+                let mut replaced = 0;
+                for unit in &mut self.state.processors {
+                    if unit.name == name && !unit.is_functional() {
+                        unit.replace();
+                        replaced += 1;
+                    }
+                }
+                if replaced == 0 {
+                    return Err(PurchaseError::NoMatchingProcessors);
+                }
+                self.push_message(format!(
+                    "Replaced {replaced} units of {name}. Fleet restored.",
+                ));
+            }
         }
-        if let Some(entry) = self.state.store_purchases.get_mut(index) {
-            *entry += 1;
+        if !matches!(
+            item.action,
+            StoreAction::ReplaceProcessor | StoreAction::ReplaceModel
+        ) {
+            if let Some(entry) = self.state.store_purchases.get_mut(index) {
+                *entry += 1;
+            }
         }
         self.push_message(format!("Purchased {} (-{cost} cr)", item.name));
         Ok(())
@@ -291,6 +507,151 @@ impl Game {
 
     pub fn total_upkeep(&self) -> u64 {
         economy::upkeep_total(&self.state.processors)
+    }
+
+    pub fn total_electricity_cost(&self) -> u64 {
+        economy::electricity_cost(&self.state.processors)
+    }
+
+    pub fn total_power_draw(&self) -> f64 {
+        self.state
+            .processors
+            .iter()
+            .map(|processor| processor.last_power_draw())
+            .sum()
+    }
+
+    pub fn thermal_paste_active(&self) -> bool {
+        self.state.thermal_paste_timer_ms > 0
+    }
+
+    pub fn accept_assist_suggestion(&mut self, processor_index: usize) -> bool {
+        let processor_name = {
+            let Some(processor) = self.state.processors.get(processor_index) else {
+                self.push_message("Select a valid processor.".to_string());
+                return false;
+            };
+            if !processor.daemon_unlocked || processor.daemon_mode != DaemonMode::Assist {
+                self.push_message(format!(
+                    "{} is not running Assist automation.",
+                    processor.name
+                ));
+                return false;
+            }
+            if !processor.is_functional() {
+                self.push_message(format!(
+                    "{} is offline and cannot take suggestions.",
+                    processor.name
+                ));
+                return false;
+            }
+            if !processor.is_idle() {
+                self.push_message(format!("{} is already working.", processor.name));
+                return false;
+            }
+            processor.name.clone()
+        };
+
+        let Some(suggestion) = self.assist_suggestion(processor_index) else {
+            self.push_message(format!(
+                "{processor_name} has no suggestions ready. Queue a job manually."
+            ));
+            return false;
+        };
+
+        if suggestion.job_index >= self.state.jobs.len() {
+            self.push_message("Suggested job is no longer available.".to_string());
+            return false;
+        }
+
+        let job = self.state.jobs.remove(suggestion.job_index);
+        let job_clone = job.clone();
+        match self.assign_job_to_processor(job_clone, processor_index, false) {
+            Ok(()) => true,
+            Err(err) => {
+                let reinsertion = suggestion.job_index.min(self.state.jobs.len());
+                self.state.jobs.insert(reinsertion, job);
+                self.push_message(format!("Assist assignment failed: {err}"));
+                false
+            }
+        }
+    }
+
+    fn replacement_cost_for_model(&self, name: &str) -> u64 {
+        self.state
+            .processors
+            .iter()
+            .filter(|processor| processor.name == name && !processor.is_functional())
+            .map(replacement_cost_for_processor)
+            .sum()
+    }
+
+    fn store_index_for(action: StoreAction) -> Option<usize> {
+        STORE_ITEMS.iter().position(|item| item.action == action)
+    }
+
+    pub fn replace_processor_direct(&mut self, index: usize) -> Result<(), PurchaseError> {
+        let store_index = Self::store_index_for(StoreAction::ReplaceProcessor)
+            .ok_or(PurchaseError::InvalidItem)?;
+        let processor_index = Some(index);
+        self.purchase_item(store_index, processor_index)
+    }
+
+    pub fn replace_model_direct(&mut self, index: usize) -> Result<(), PurchaseError> {
+        let store_index =
+            Self::store_index_for(StoreAction::ReplaceModel).ok_or(PurchaseError::InvalidItem)?;
+        let processor_index = Some(index);
+        self.purchase_item(store_index, processor_index)
+    }
+
+    pub fn cycle_daemon_mode(&mut self, index: usize) {
+        let message = if let Some(processor) = self.state.processors.get_mut(index) {
+            if !self.state.daemon_unlocked || !processor.daemon_unlocked {
+                Some(format!(
+                    "{} lacks daemon firmware. Install microcode to unlock.",
+                    processor.name
+                ))
+            } else if !processor.is_functional() {
+                Some(format!(
+                    "{} is offline and cannot change automation mode.",
+                    processor.name
+                ))
+            } else {
+                processor.daemon_mode = match processor.daemon_mode {
+                    DaemonMode::Off => DaemonMode::Assist,
+                    DaemonMode::Assist => DaemonMode::Auto,
+                    DaemonMode::Auto => DaemonMode::Off,
+                };
+                let label = match processor.daemon_mode {
+                    DaemonMode::Off => "Off",
+                    DaemonMode::Assist => "Assist",
+                    DaemonMode::Auto => "Auto",
+                };
+                Some(format!("{} automation mode -> {label}.", processor.name))
+            }
+        } else {
+            Some("Select a valid processor.".to_string())
+        };
+        if let Some(msg) = message {
+            self.push_message(msg);
+        }
+    }
+
+    pub fn toggle_honor_cooling(&mut self, index: usize) {
+        let message = if let Some(processor) = self.state.processors.get_mut(index) {
+            processor.honor_cooling_mins = !processor.honor_cooling_mins;
+            let state = if processor.honor_cooling_mins {
+                "will honor cooling minimums"
+            } else {
+                "will override cooling minimums"
+            };
+            Some(format!("{} {} when auto-assigning.", processor.name, state))
+        } else {
+            Some("Select a valid processor.".to_string())
+        };
+        if let Some(msg) = message {
+            self.push_message(msg);
+        }
     }
 
     fn unlock_instruction_tag(&mut self, tag: &str) -> bool {
@@ -347,14 +708,23 @@ impl Game {
             return;
         }
         let delta_ms = delta.as_millis() as u64;
-        let mut completed = Vec::new();
+        let cooling_bonus = if self.state.thermal_paste_timer_ms > 0 {
+            1
+        } else {
+            0
+        };
+        let mut events = Vec::new();
         for (index, processor) in self.state.processors.iter_mut().enumerate() {
-            if let Some(done) = processor.tick(delta_ms) {
-                completed.push((index, done));
+            if let Some(event) = processor.tick(delta_ms, &mut self.rng, cooling_bonus) {
+                events.push((index, event));
             }
         }
-        for (index, done) in completed {
-            self.resolve_completed_job(index, done);
+        for (index, event) in events {
+            match event {
+                ProcessorEvent::Completed(done) => self.resolve_completed_job(index, done),
+                ProcessorEvent::BurntOut { job } => self.handle_burnout(index, job),
+                ProcessorEvent::Destroyed { job } => self.handle_destruction(index, job),
+            }
         }
     }
 
@@ -368,7 +738,7 @@ impl Game {
             let quality = economy::roll_quality(
                 &completed.job,
                 processor,
-                completed.daemon_penalty,
+                completed.daemon_penalty.as_ref(),
                 &mut self.rng,
             );
             (quality, processor_name)
@@ -390,16 +760,44 @@ impl Game {
         ));
     }
 
+    fn handle_burnout(&mut self, processor_index: usize, job: Job) {
+        if let Some(processor) = self.state.processors.get(processor_index) {
+            let processor_name = processor.name.clone();
+            self.push_message(format!(
+                "{processor_name} burnt out while processing {}. Unit offline.",
+                job.name
+            ));
+        }
+    }
+
+    fn handle_destruction(&mut self, processor_index: usize, job: Job) {
+        if let Some(processor) = self.state.processors.get(processor_index) {
+            let processor_name = processor.name.clone();
+            self.push_message(format!(
+                "{processor_name} was destroyed during {}. Replacement required.",
+                job.name
+            ));
+        }
+    }
+
     fn apply_daily_cycle(&mut self) {
         let upkeep = self.total_upkeep();
-        if upkeep > 0 {
-            if self.state.credits >= upkeep {
-                self.state.credits -= upkeep;
-                self.push_message(format!("Paid upkeep of {upkeep} credits."));
+        let electricity = self.total_electricity_cost();
+        let total_cost = upkeep + electricity;
+        if total_cost > 0 {
+            if self.state.credits >= total_cost {
+                self.state.credits -= total_cost;
+                if electricity > 0 {
+                    self.push_message(format!(
+                        "Paid upkeep {upkeep} cr + electricity {electricity} cr (total {total_cost})."
+                    ));
+                } else {
+                    self.push_message(format!("Paid upkeep of {upkeep} credits."));
+                }
             } else {
                 self.state.credits = 0;
                 self.push_message(format!(
-                    "Upkeep cost {upkeep} exceeded reserves; treasury depleted."
+                    "Operating costs {total_cost} exceeded reserves; treasury depleted."
                 ));
             }
         }
@@ -411,20 +809,148 @@ impl Game {
     }
 
     fn try_daemon_assignment(&mut self) {
-        loop {
+        if self.state.jobs.is_empty() {
+            return;
+        }
+        let cooling_bonus = if self.state.thermal_paste_timer_ms > 0 {
+            1
+        } else {
+            0
+        };
+        let mut auto_indices: Vec<usize> = self
+            .state
+            .processors
+            .iter()
+            .enumerate()
+            .filter(|(_, processor)| {
+                processor.daemon_unlocked
+                    && processor.daemon_mode == DaemonMode::Auto
+                    && processor.is_idle()
+                    && processor.is_functional()
+            })
+            .map(|(index, _)| index)
+            .collect();
+
+        auto_indices.sort_by(|a, b| {
+            let pa = &self.state.processors[*a];
+            let pb = &self.state.processors[*b];
+            pb.daemon_priority
+                .cmp(&pa.daemon_priority)
+                .then_with(|| pb.speed.partial_cmp(&pa.speed).unwrap_or(Ordering::Equal))
+        });
+
+        for processor_index in auto_indices {
             if self.state.jobs.is_empty() {
                 break;
             }
-            let Some(processor_index) = self.state.processors.iter().position(|p| p.is_idle())
-            else {
-                break;
+            let Some(job_index) = self.choose_daemon_job(processor_index, cooling_bonus) else {
+                continue;
             };
-            let job = self.state.jobs.remove(0);
+            let job = self.state.jobs.remove(job_index);
             if let Err(err) = self.assign_job_to_processor(job, processor_index, true) {
                 self.push_message(format!("Daemon failed assignment: {err}"));
-                break;
             }
         }
+    }
+
+    fn choose_daemon_job(&self, processor_index: usize, cooling_bonus_levels: u8) -> Option<usize> {
+        let processor = self.state.processors.get(processor_index)?;
+        let mut best: Option<(usize, f64)> = None;
+        for (job_index, job) in self.state.jobs.iter().enumerate() {
+            if !processor.supports(&job.tag) {
+                continue;
+            }
+            let evaluation = processor.evaluate_job(job, cooling_bonus_levels);
+            if processor.honor_cooling_mins
+                && processor.requires_cooling_min > evaluation.effective_cooling
+                && job.tag != jobs::GENERAL_TAG
+            {
+                continue;
+            }
+            if evaluation.reliability < 0.35 {
+                continue;
+            }
+            if processor.honor_cooling_mins && evaluation.heat > 1.8 {
+                continue;
+            }
+            let duration =
+                economy::assignment_duration_ms(job, processor, Some(&processor.daemon_penalty))
+                    as f64;
+            let base_score = if duration > 0.0 {
+                (job.base_reward as f64 / duration).max(0.0)
+            } else {
+                job.base_reward as f64
+            };
+            let affinity = processor
+                .daemon_affinity
+                .get(&job.tag)
+                .copied()
+                .unwrap_or(0.0);
+            let safety = (evaluation.reliability - 0.7) * 0.5;
+            let score = base_score + affinity + safety;
+            let update = match &best {
+                Some((_, best_score)) => score > *best_score,
+                None => true,
+            };
+            if update {
+                best = Some((job_index, score));
+            }
+        }
+        best.map(|(job_index, _)| job_index)
+    }
+
+    pub fn assist_suggestion(&self, index: usize) -> Option<AssistSuggestion> {
+        let processor = self.state.processors.get(index)?;
+        if !processor.daemon_unlocked
+            || processor.daemon_mode != DaemonMode::Assist
+            || !processor.is_idle()
+            || !processor.is_functional()
+        {
+            return None;
+        }
+        if self.state.jobs.is_empty() {
+            return None;
+        }
+        let cooling_bonus = if self.state.thermal_paste_timer_ms > 0 {
+            1
+        } else {
+            0
+        };
+        let mut best: Option<(usize, f64, f64, JobEvaluation)> = None;
+        for (job_index, job) in self.state.jobs.iter().enumerate() {
+            if !processor.supports(&job.tag) {
+                continue;
+            }
+            let evaluation = processor.evaluate_job(job, cooling_bonus);
+            if evaluation.reliability < 0.3 {
+                continue;
+            }
+            if processor.honor_cooling_mins
+                && processor.requires_cooling_min > evaluation.effective_cooling
+                && job.tag != jobs::GENERAL_TAG
+            {
+                continue;
+            }
+            let duration = economy::assignment_duration_ms(job, processor, None) as f64 / 1000.0;
+            let score = if duration > 0.0 {
+                (job.base_reward as f64 / duration).max(0.0)
+            } else {
+                job.base_reward as f64
+            };
+            let replace = match &best {
+                Some((_, best_score, _, _)) => score > *best_score,
+                None => true,
+            };
+            if replace {
+                best = Some((job_index, score, duration, evaluation));
+            }
+        }
+        best.map(|(job_index, _, duration, evaluation)| AssistSuggestion {
+            job_index,
+            eta_secs: duration,
+            reliability: evaluation.reliability,
+            heat: evaluation.heat,
+        })
     }
 
     fn push_message(&mut self, message: String) {
@@ -445,15 +971,21 @@ pub struct StoreItem {
     pub max_purchases: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StoreAction {
     IncreaseSpeed,
     ImproveQuality,
     ExpandStorage,
     UnlockInstructionSet { tag: &'static str },
+    UpgradeCooling,
+    UpgradeHardening,
+    ApplyThermalPaste,
+    ReplaceProcessor,
+    ReplaceModel,
+    InstallDaemonFirmware,
 }
 
-const STORE_ITEMS: [StoreItem; 4] = [
+const STORE_ITEMS: [StoreItem; 10] = [
     StoreItem {
         name: "Clock Tuning",
         description: "Trim execution cycles for all processors (+0.05 speed each purchase).",
@@ -488,6 +1020,54 @@ const STORE_ITEMS: [StoreItem; 4] = [
         },
         max_purchases: Some(1),
     },
+    StoreItem {
+        name: "Cooling Kit",
+        description: "Install additional cooling on the selected processor (+1 level up to cap).",
+        base_cost: 90,
+        cost_step: 35,
+        action: StoreAction::UpgradeCooling,
+        max_purchases: None,
+    },
+    StoreItem {
+        name: "Hardening Module",
+        description: "Radiation shielding and error correction for the selected processor (+1 hardening).",
+        base_cost: 140,
+        cost_step: 55,
+        action: StoreAction::UpgradeHardening,
+        max_purchases: None,
+    },
+    StoreItem {
+        name: "Service-Grade Thermal Paste",
+        description: "Refreshes thermal interface material for the day (temporary +1 cooling level).",
+        base_cost: 60,
+        cost_step: 20,
+        action: StoreAction::ApplyThermalPaste,
+        max_purchases: None,
+    },
+    StoreItem {
+        name: "Daemon Microcode",
+        description: "Unlock automation firmware for the selected processor and ease penalties.",
+        base_cost: 180,
+        cost_step: 80,
+        action: StoreAction::InstallDaemonFirmware,
+        max_purchases: None,
+    },
+    StoreItem {
+        name: "Replace Selected Unit",
+        description: "Swap the highlighted processor chassis at the model's service rate.",
+        base_cost: 0,
+        cost_step: 0,
+        action: StoreAction::ReplaceProcessor,
+        max_purchases: None,
+    },
+    StoreItem {
+        name: "Replace Model Fleet",
+        description: "Replace all burnt or destroyed units of the selected model at bulk rate.",
+        base_cost: 0,
+        cost_step: 0,
+        action: StoreAction::ReplaceModel,
+        max_purchases: None,
+    },
 ];
 
 #[derive(Debug, Error)]
@@ -500,12 +1080,31 @@ pub enum PurchaseError {
     MaxedOut { item: &'static str },
     #[error("{tag} instruction set already unlocked")]
     InstructionAlreadyUnlocked { tag: String },
+    #[error("select a processor first")]
+    ProcessorSelectionRequired,
+    #[error("selected processor is operational")]
+    ProcessorHealthy,
+    #[error("no matching processors require replacement")]
+    NoMatchingProcessors,
+    #[error("upgrade already at maximum level")]
+    UpgradeAtCap,
+    #[error("daemon firmware already installed")]
+    DaemonAlreadyInstalled,
+}
+
+fn replacement_cost_for_processor(processor: &ProcessorState) -> u64 {
+    if processor.is_functional() {
+        return 0;
+    }
+    let base = (processor.purchase_cost as f64 * processor.replace_cost_ratio).round() as u64;
+    base.max(1)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sim::jobs::SIMD_TAG;
+    use crate::sim::jobs::{GENERAL_TAG, Job, SIMD_TAG};
+    use crate::sim::processors::{DaemonMode, ProcessorStatus};
 
     #[test]
     fn purchasing_microcode_unlocks_simd_tag() {
@@ -516,11 +1115,12 @@ mod tests {
             .position(|item| matches!(item.action, StoreAction::UnlockInstructionSet { .. }))
             .expect("microcode item present");
         let cost = game
-            .item_cost(idx)
+            .item_cost(idx, None)
             .expect("microcode should be purchasable");
 
         assert!(!game.is_instruction_unlocked(SIMD_TAG));
-        game.purchase_item(idx).expect("purchase should succeed");
+        game.purchase_item(idx, None)
+            .expect("purchase should succeed");
 
         assert!(game.is_instruction_unlocked(SIMD_TAG));
         assert!(game.state.unlocked_tags.iter().any(|tag| tag == SIMD_TAG));
@@ -533,8 +1133,97 @@ mod tests {
         assert_eq!(game.store_purchases(idx), Some(1));
         assert_eq!(game.state.credits, 1_000 - cost);
         assert!(matches!(
-            game.purchase_item(idx),
+            game.purchase_item(idx, None),
             Err(PurchaseError::MaxedOut { .. })
+        ));
+    }
+
+    #[test]
+    fn replacing_burnt_out_processor_spends_credits() {
+        let mut game = Game::fresh();
+        game.state.credits = 500;
+        let processor = &mut game.state.processors[0];
+        processor.status = ProcessorStatus::BurntOut;
+        let expected_cost =
+            ((processor.purchase_cost as f64) * processor.replace_cost_ratio).round() as u64;
+
+        game.replace_processor_direct(0)
+            .expect("replacement should succeed");
+
+        assert_eq!(game.state.credits, 500 - expected_cost);
+        assert!(matches!(
+            game.state.processors[0].status,
+            ProcessorStatus::Idle
+        ));
+        assert!(game.state.processors[0].wear <= f64::EPSILON);
+    }
+
+    #[test]
+    fn cycling_daemon_mode_traverses_states() {
+        let mut game = Game::fresh();
+        game.state.daemon_unlocked = true;
+        let processor = &mut game.state.processors[0];
+        processor.daemon_unlocked = true;
+
+        assert_eq!(processor.daemon_mode, DaemonMode::Off);
+        game.cycle_daemon_mode(0);
+        assert_eq!(game.state.processors[0].daemon_mode, DaemonMode::Assist);
+        game.cycle_daemon_mode(0);
+        assert_eq!(game.state.processors[0].daemon_mode, DaemonMode::Auto);
+        game.cycle_daemon_mode(0);
+        assert_eq!(game.state.processors[0].daemon_mode, DaemonMode::Off);
+    }
+
+    #[test]
+    fn cooling_upgrade_respects_cap() {
+        let mut game = Game::fresh();
+        game.state.credits = 1_000;
+        let processor_index = 0;
+        let cooling_idx = STORE_ITEMS
+            .iter()
+            .position(|item| item.action == StoreAction::UpgradeCooling)
+            .expect("cooling kit present");
+
+        game.purchase_item(cooling_idx, Some(processor_index))
+            .expect("upgrade should succeed");
+        assert_eq!(game.state.processors[processor_index].cooling_level, 1);
+
+        // Bump to cap
+        game.purchase_item(cooling_idx, Some(processor_index))
+            .expect("second upgrade should succeed");
+        game.purchase_item(cooling_idx, Some(processor_index))
+            .expect("third upgrade should succeed");
+
+        assert_eq!(game.state.processors[processor_index].cooling_level, 3);
+        assert!(matches!(
+            game.purchase_item(cooling_idx, Some(processor_index)),
+            Err(PurchaseError::UpgradeAtCap)
+        ));
+    }
+
+    #[test]
+    fn assist_mode_assigns_suggested_job() {
+        let mut game = Game::fresh();
+        game.state.daemon_unlocked = true;
+        let processor = &mut game.state.processors[0];
+        processor.daemon_unlocked = true;
+        processor.daemon_mode = DaemonMode::Assist;
+
+        game.state.jobs.push(Job {
+            id: 42,
+            name: "Assist Contract".to_string(),
+            tag: GENERAL_TAG.to_string(),
+            base_time_ms: 5_000,
+            base_reward: 150,
+            quality_target: 60,
+            data_output: 30,
+        });
+
+        assert!(game.accept_assist_suggestion(0));
+        assert!(game.state.jobs.is_empty());
+        assert!(matches!(
+            game.state.processors[0].status,
+            ProcessorStatus::Working(_)
         ));
     }
 }

--- a/src/sim/processors.rs
+++ b/src/sim/processors.rs
@@ -1,6 +1,69 @@
 use crate::sim::jobs::Job;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use thiserror::Error;
+
+const DEFAULT_RELIABILITY: f64 = 0.995;
+const DEFAULT_COOLING_CAP: u8 = 3;
+const DEFAULT_REPLACE_RATIO: f64 = 0.35;
+const DEFAULT_POWER_DRAW: f64 = 4.2;
+const DEFAULT_HEAT_OUTPUT: f64 = 1.0;
+const DEFAULT_PURCHASE_COST: u64 = 180;
+const HEAT_FAILURE_MULTIPLIER: f64 = 0.12;
+const ELECTRIC_COOLING_FACTOR: f64 = 0.05;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonPenalty {
+    pub quality: i8,
+    pub time_multiplier: f64,
+}
+
+impl Default for DaemonPenalty {
+    fn default() -> Self {
+        Self {
+            quality: -5,
+            time_multiplier: 1.10,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DaemonMode {
+    Off,
+    Assist,
+    Auto,
+}
+
+impl Default for DaemonMode {
+    fn default() -> Self {
+        DaemonMode::Off
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessorWork {
+    pub job: Job,
+    pub remaining_ms: u64,
+    pub total_ms: u64,
+    pub daemon_penalty: Option<DaemonPenalty>,
+    #[serde(default)]
+    pub overheating: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ProcessorStatus {
+    Idle,
+    Working(Box<ProcessorWork>),
+    BurntOut,
+    Destroyed,
+}
+
+impl Default for ProcessorStatus {
+    fn default() -> Self {
+        ProcessorStatus::Idle
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessorState {
@@ -11,56 +74,237 @@ pub struct ProcessorState {
     pub upkeep_cost: u64,
     #[serde(default)]
     pub status: ProcessorStatus,
+    #[serde(default = "default_reliability_base")]
+    pub reliability_base: f64,
+    #[serde(default)]
+    pub cooling_required: bool,
+    #[serde(default)]
+    pub cooling_level: u8,
+    #[serde(default = "default_cooling_cap")]
+    pub cooling_cap: u8,
+    #[serde(default)]
+    pub hardening_level: u8,
+    #[serde(default)]
+    pub requires_cooling_min: u8,
+    #[serde(default)]
+    pub finite_lifespan: bool,
+    #[serde(default)]
+    pub mttf_ticks: u64,
+    #[serde(default)]
+    pub wear: f64,
+    #[serde(default)]
+    pub fragility: f64,
+    #[serde(default = "default_replace_cost_ratio")]
+    pub replace_cost_ratio: f64,
+    #[serde(default = "default_power_draw_base")]
+    pub power_draw_base: f64,
+    #[serde(default)]
+    pub power_draw_mod: HashMap<String, f64>,
+    #[serde(default = "default_heat_output_base")]
+    pub heat_output_base: f64,
+    #[serde(default = "default_purchase_cost")]
+    pub purchase_cost: u64,
+    #[serde(default)]
+    pub daemon_mode: DaemonMode,
+    #[serde(default)]
+    pub daemon_unlocked: bool,
+    #[serde(default)]
+    pub daemon_affinity: HashMap<String, f64>,
+    #[serde(default)]
+    pub daemon_priority: i32,
+    #[serde(default = "default_honor_cooling")]
+    pub honor_cooling_mins: bool,
+    #[serde(default)]
+    pub daemon_penalty: DaemonPenalty,
+    #[serde(skip)]
+    pub last_reliability: f64,
+    #[serde(skip)]
+    pub last_heat: f64,
+    #[serde(skip)]
+    pub last_power_draw: f64,
+    #[serde(skip)]
+    pub last_effective_cooling: u8,
+}
+
+fn default_reliability_base() -> f64 {
+    DEFAULT_RELIABILITY
+}
+
+fn default_cooling_cap() -> u8 {
+    DEFAULT_COOLING_CAP
+}
+
+fn default_replace_cost_ratio() -> f64 {
+    DEFAULT_REPLACE_RATIO
+}
+
+fn default_power_draw_base() -> f64 {
+    DEFAULT_POWER_DRAW
+}
+
+fn default_heat_output_base() -> f64 {
+    DEFAULT_HEAT_OUTPUT
+}
+
+fn default_purchase_cost() -> u64 {
+    DEFAULT_PURCHASE_COST
+}
+
+fn default_honor_cooling() -> bool {
+    true
 }
 
 impl ProcessorState {
     pub fn starter() -> Self {
-        Self {
+        let mut processor = Self {
             name: "Model F12-Scalar".to_string(),
             speed: 1.0,
             quality_bias: 0,
             instruction_set: vec!["GENERAL".to_string()],
             upkeep_cost: 8,
             status: ProcessorStatus::Idle,
+            reliability_base: DEFAULT_RELIABILITY,
+            cooling_required: false,
+            cooling_level: 0,
+            cooling_cap: DEFAULT_COOLING_CAP,
+            hardening_level: 0,
+            requires_cooling_min: 0,
+            finite_lifespan: false,
+            mttf_ticks: 0,
+            wear: 0.0,
+            fragility: 0.0,
+            replace_cost_ratio: DEFAULT_REPLACE_RATIO,
+            power_draw_base: DEFAULT_POWER_DRAW,
+            power_draw_mod: HashMap::new(),
+            heat_output_base: DEFAULT_HEAT_OUTPUT,
+            purchase_cost: DEFAULT_PURCHASE_COST,
+            daemon_mode: DaemonMode::Off,
+            daemon_unlocked: false,
+            daemon_affinity: HashMap::new(),
+            daemon_priority: 0,
+            honor_cooling_mins: true,
+            daemon_penalty: DaemonPenalty::default(),
+            last_reliability: DEFAULT_RELIABILITY,
+            last_heat: 0.0,
+            last_power_draw: DEFAULT_POWER_DRAW,
+            last_effective_cooling: 0,
+        };
+        processor.ensure_runtime_defaults();
+        processor
+    }
+
+    pub fn ensure_runtime_defaults(&mut self) {
+        if self.cooling_cap == 0 {
+            self.cooling_cap = DEFAULT_COOLING_CAP;
         }
+        if self.replace_cost_ratio == 0.0 {
+            self.replace_cost_ratio = DEFAULT_REPLACE_RATIO;
+        }
+        if self.reliability_base <= 0.0 {
+            self.reliability_base = DEFAULT_RELIABILITY;
+        }
+        if (self.power_draw_base - 0.0).abs() < f64::EPSILON {
+            self.power_draw_base = DEFAULT_POWER_DRAW;
+        }
+        if (self.heat_output_base - 0.0).abs() < f64::EPSILON {
+            self.heat_output_base = DEFAULT_HEAT_OUTPUT;
+        }
+        if self.purchase_cost == 0 {
+            self.purchase_cost = DEFAULT_PURCHASE_COST;
+        }
+        self.last_reliability = self.reliability_base;
+        self.last_heat = 0.0;
+        self.last_effective_cooling = self.cooling_level;
+        self.last_power_draw = self.idle_power_draw();
+    }
+
+    pub fn idle_power_draw(&self) -> f64 {
+        let cooling_factor = 1.0 + ELECTRIC_COOLING_FACTOR * self.cooling_level as f64;
+        (self.power_draw_base * cooling_factor).max(0.0)
     }
 
     pub fn is_idle(&self) -> bool {
         matches!(self.status, ProcessorStatus::Idle)
     }
 
+    pub fn is_functional(&self) -> bool {
+        !matches!(
+            self.status,
+            ProcessorStatus::BurntOut | ProcessorStatus::Destroyed
+        )
+    }
+
     pub fn supports(&self, tag: &str) -> bool {
         self.instruction_set.iter().any(|known| known == tag)
     }
 
-    pub fn assign(&mut self, job: Job, total_ms: u64, daemon_penalty: bool) {
-        self.status = ProcessorStatus::Busy {
+    pub fn assign(&mut self, job: Job, total_ms: u64, daemon_penalty: Option<DaemonPenalty>) {
+        self.status = ProcessorStatus::Working(Box::new(ProcessorWork {
             job,
             remaining_ms: total_ms,
             total_ms,
             daemon_penalty,
-        };
+            overheating: false,
+        }));
+        self.last_power_draw = self.idle_power_draw();
     }
 
-    pub fn tick(&mut self, delta_ms: u64) -> Option<CompletedJob> {
+    pub fn tick(
+        &mut self,
+        delta_ms: u64,
+        rng: &mut impl Rng,
+        cooling_bonus_levels: u8,
+    ) -> Option<ProcessorEvent> {
+        let evaluation_snapshot = match &self.status {
+            ProcessorStatus::Working(work) => {
+                Some(self.evaluate_job(&work.job, cooling_bonus_levels))
+            }
+            _ => None,
+        };
         match &mut self.status {
-            ProcessorStatus::Idle => None,
-            ProcessorStatus::Busy {
-                remaining_ms,
-                job,
-                daemon_penalty,
-                total_ms: _,
-            } => {
-                if *remaining_ms > delta_ms {
-                    *remaining_ms -= delta_ms;
+            ProcessorStatus::Idle => {
+                self.last_power_draw = self.idle_power_draw();
+                None
+            }
+            ProcessorStatus::BurntOut | ProcessorStatus::Destroyed => None,
+            ProcessorStatus::Working(work) => {
+                let evaluation = evaluation_snapshot.expect("evaluation missing");
+                self.last_reliability = evaluation.reliability;
+                self.last_heat = evaluation.heat;
+                self.last_effective_cooling = evaluation.effective_cooling;
+                self.last_power_draw = evaluation.power_draw;
+
+                if evaluation.reliability <= 0.0 || rng.gen_range(0.0..1.0) > evaluation.reliability
+                {
+                    let job = work.job.clone();
+                    self.status = ProcessorStatus::BurntOut;
+                    return Some(ProcessorEvent::BurntOut { job });
+                }
+
+                if self.finite_lifespan && self.mttf_ticks > 0 {
+                    let base_wear = delta_ms as f64 / self.mttf_ticks as f64;
+                    let heat_wear = evaluation.heat.max(0.0) * 0.0005 * (delta_ms as f64 / 1000.0);
+                    let hazard_wear = evaluation.hazard_penalty * 0.05;
+                    self.wear += base_wear + heat_wear + hazard_wear;
+                    if self.wear >= 1.0 {
+                        let job = work.job.clone();
+                        self.status = ProcessorStatus::Destroyed;
+                        return Some(ProcessorEvent::Destroyed { job });
+                    }
+                }
+
+                if work.remaining_ms > delta_ms {
+                    work.remaining_ms -= delta_ms;
+                    work.overheating = evaluation.heat > 1.0
+                        || self.requires_cooling_min > evaluation.effective_cooling;
                     None
                 } else {
                     let completed_job = CompletedJob {
-                        job: job.clone(),
-                        daemon_penalty: *daemon_penalty,
+                        job: work.job.clone(),
+                        daemon_penalty: work.daemon_penalty.clone(),
                     };
                     self.status = ProcessorStatus::Idle;
-                    Some(completed_job)
+                    Some(ProcessorEvent::Completed(completed_job))
                 }
             }
         }
@@ -68,37 +312,148 @@ impl ProcessorState {
 
     pub fn remaining_and_total(&self) -> Option<(u64, u64)> {
         match &self.status {
-            ProcessorStatus::Idle => None,
-            ProcessorStatus::Busy {
-                remaining_ms,
-                total_ms,
-                ..
-            } => Some((*remaining_ms, *total_ms)),
+            ProcessorStatus::Working(work) => Some((work.remaining_ms, work.total_ms)),
+            _ => None,
+        }
+    }
+
+    pub fn replace(&mut self) {
+        self.status = ProcessorStatus::Idle;
+        self.wear = 0.0;
+        self.last_heat = 0.0;
+        self.last_reliability = self.reliability_base;
+        self.last_effective_cooling = self.cooling_level;
+        self.last_power_draw = self.idle_power_draw();
+    }
+
+    pub fn reliability_display(&self) -> f64 {
+        self.last_reliability.max(0.0)
+    }
+
+    pub fn heat_display(&self) -> f64 {
+        self.last_heat
+    }
+
+    pub fn cooling_cap(&self) -> u8 {
+        self.cooling_cap
+    }
+
+    pub fn last_power_draw(&self) -> f64 {
+        self.last_power_draw
+    }
+
+    pub fn evaluate_job(&self, job: &Job, cooling_bonus_levels: u8) -> JobEvaluation {
+        let effective_cooling =
+            effective_cooling_level(self.cooling_level, self.cooling_cap, cooling_bonus_levels);
+        let cooling_reduction = cooling_reduction(effective_cooling);
+        let mut heat =
+            self.heat_output_base * (1.0 + load_modifier(&self.power_draw_mod, &job.tag));
+        heat *= 1.0 - cooling_reduction;
+        if self.cooling_required && effective_cooling == 0 {
+            heat += 1.2;
+        }
+        if self.requires_cooling_min > effective_cooling {
+            heat += 0.8 * (self.requires_cooling_min - effective_cooling) as f64;
+        }
+        let hazard = tag_hazard(&job.tag);
+        let hazard_penalty = hazard * hardening_multiplier(self.hardening_level, &job.tag);
+        let mut reliability = self.reliability_base;
+        reliability -= heat.max(0.0) * HEAT_FAILURE_MULTIPLIER;
+        reliability -= hazard_penalty;
+        reliability += cooling_reliability_bonus(effective_cooling);
+        if self.cooling_required && effective_cooling == 0 {
+            reliability -= 0.25;
+        }
+        if self.requires_cooling_min > effective_cooling {
+            reliability -= 0.15 * (self.requires_cooling_min - effective_cooling) as f64;
+        }
+        reliability -= self.fragility * heat.max(0.0);
+        reliability = reliability.clamp(0.0, 0.999);
+        let cooling_factor = 1.0 + ELECTRIC_COOLING_FACTOR * effective_cooling as f64;
+        let mut power_draw =
+            self.power_draw_base * (1.0 + load_modifier(&self.power_draw_mod, &job.tag));
+        if power_draw < 0.0 {
+            power_draw = 0.0;
+        }
+        let power_draw = (power_draw * cooling_factor).max(0.0);
+        JobEvaluation {
+            reliability,
+            heat,
+            effective_cooling,
+            hazard_penalty,
+            power_draw,
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ProcessorStatus {
-    Idle,
-    Busy {
-        job: Job,
-        remaining_ms: u64,
-        total_ms: u64,
-        daemon_penalty: bool,
-    },
+#[derive(Debug, Clone)]
+pub struct JobEvaluation {
+    pub reliability: f64,
+    pub heat: f64,
+    pub effective_cooling: u8,
+    pub hazard_penalty: f64,
+    pub power_draw: f64,
 }
 
-impl Default for ProcessorStatus {
-    fn default() -> Self {
-        ProcessorStatus::Idle
+fn effective_cooling_level(level: u8, cap: u8, bonus: u8) -> u8 {
+    let effective = level as u16 + bonus as u16;
+    let max_allowed = cap as u16 + bonus as u16;
+    effective.min(max_allowed) as u8
+}
+
+fn cooling_reduction(level: u8) -> f64 {
+    match level {
+        0 => 0.0,
+        1 => 0.25,
+        2 => 0.45,
+        3 => 0.60,
+        other => 0.60 + 0.05 * (other.saturating_sub(3)) as f64,
     }
 }
 
+fn cooling_reliability_bonus(level: u8) -> f64 {
+    match level {
+        0 => 0.0,
+        1 => 0.01,
+        2 => 0.02,
+        3 => 0.03,
+        other => 0.03 + 0.005 * (other.saturating_sub(3)) as f64,
+    }
+}
+
+fn tag_hazard(tag: &str) -> f64 {
+    match tag {
+        "RADIATION" => 0.02,
+        "ANGEL" => 0.03,
+        "SURVEILLANCE" => 0.01,
+        "SIMD" => 0.015,
+        _ => 0.0,
+    }
+}
+
+fn hardening_multiplier(level: u8, tag: &str) -> f64 {
+    if tag == "RADIATION" || tag == "ANGEL" || tag == "SURVEILLANCE" {
+        (1.0 - 0.2 * level as f64).max(0.2)
+    } else {
+        (1.0 - 0.05 * level as f64).max(0.5)
+    }
+}
+
+fn load_modifier(mods: &HashMap<String, f64>, tag: &str) -> f64 {
+    mods.get(tag).copied().unwrap_or(0.0)
+}
+
 #[derive(Debug)]
+pub enum ProcessorEvent {
+    Completed(CompletedJob),
+    BurntOut { job: Job },
+    Destroyed { job: Job },
+}
+
+#[derive(Debug, Clone)]
 pub struct CompletedJob {
     pub job: Job,
-    pub daemon_penalty: bool,
+    pub daemon_penalty: Option<DaemonPenalty>,
 }
 
 #[derive(Debug, Error)]
@@ -109,4 +464,6 @@ pub enum AssignmentError {
     ProcessorBusy,
     #[error("processor lacks instruction {0}")]
     IncompatibleInstruction(String),
+    #[error("processor is not operational")]
+    ProcessorInoperative,
 }

--- a/src/ui/jobs_view.rs
+++ b/src/ui/jobs_view.rs
@@ -17,6 +17,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
         .iter()
         .map(|job| {
             let time_secs = job.base_time_ms as f64 / 1000.0;
+            let hazard_note = hazard_label(&job.tag);
             let line = Line::from(vec![
                 Span::styled(job.name.clone(), Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
@@ -27,8 +28,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
                 Span::raw(format!("| Q{}", job.quality_target)),
             ]);
             let detail = Line::from(vec![Span::raw(format!(
-                "Tag: {} • Data yield: {} units",
-                job.tag, job.data_output
+                "Tag: {} • {} • Data: {} units",
+                job.tag, hazard_note, job.data_output
             ))]);
             ListItem::new(vec![line, detail])
         })
@@ -56,4 +57,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
         state.select(Some(selection));
     }
     frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn hazard_label(tag: &str) -> &'static str {
+    match tag {
+        crate::sim::jobs::SIMD_TAG => "High load",
+        "RADIATION" => "Radiation hazard",
+        "ANGEL" => "ANGEL exposure",
+        "SURVEILLANCE" => "Surveillance risk",
+        _ => "Routine",
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 use crate::app::App;
 use crate::sim::game::Game;
+use crate::sim::processors::DaemonMode;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
@@ -48,12 +49,22 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
         .as_ref()
         .map(|job| job.name.as_str())
         .unwrap_or("None");
-    let daemon = if !game.state.daemon_unlocked {
+    let automation_summary = if !game.state.daemon_unlocked {
         "Locked".to_string()
-    } else if game.state.daemon_enabled {
-        "Enabled".to_string()
     } else {
-        "Disabled".to_string()
+        let auto = game
+            .state
+            .processors
+            .iter()
+            .filter(|p| p.daemon_mode == DaemonMode::Auto)
+            .count();
+        let assist = game
+            .state
+            .processors
+            .iter()
+            .filter(|p| p.daemon_mode == DaemonMode::Assist)
+            .count();
+        format!("{auto} auto / {assist} assist")
     };
 
     let lines = vec![
@@ -71,8 +82,8 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
             ),
             Span::raw("  •  Pending: "),
             Span::styled(pending.to_string(), Style::default().fg(Color::Cyan)),
-            Span::raw("  •  Daemon: "),
-            Span::styled(daemon, Style::default().fg(Color::Magenta)),
+            Span::raw("  •  Automation: "),
+            Span::styled(automation_summary, Style::default().fg(Color::Magenta)),
         ]),
         Line::from(vec![Span::raw(
             "Use Tab to shift focus, Enter to interact with the highlighted panel.",
@@ -99,7 +110,13 @@ fn render_footer(frame: &mut Frame, area: Rect) {
         Span::styled("[S]", Style::default().fg(Color::Yellow)),
         Span::raw(" store  •  "),
         Span::styled("[D]", Style::default().fg(Color::Yellow)),
-        Span::raw(" toggle daemon  •  "),
+        Span::raw(" cycle automation  •  "),
+        Span::styled("[Shift+D]", Style::default().fg(Color::Yellow)),
+        Span::raw(" cooling safety  •  "),
+        Span::styled("[R]", Style::default().fg(Color::Yellow)),
+        Span::raw(" replace unit  •  "),
+        Span::styled("[Shift+R]", Style::default().fg(Color::Yellow)),
+        Span::raw(" replace model  •  "),
         Span::styled("[Q]", Style::default().fg(Color::Yellow)),
         Span::raw(" save & quit"),
     ]))

--- a/src/ui/processors_view.rs
+++ b/src/ui/processors_view.rs
@@ -1,6 +1,6 @@
 use crate::app::{App, FocusTarget};
-use crate::sim::game::Game;
-use crate::sim::processors::ProcessorStatus;
+use crate::sim::game::{AssistSuggestion, Game};
+use crate::sim::processors::{DaemonMode, ProcessorStatus};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 
@@ -13,7 +13,20 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
     };
 
     let mut items: Vec<ListItem> = Vec::new();
-    for processor in &game.state.processors {
+    for (index, processor) in game.state.processors.iter().enumerate() {
+        let reliability_pct = processor.reliability_display() * 100.0;
+        let reliability_style = if reliability_pct >= 90.0 {
+            Style::default().fg(Color::LightGreen)
+        } else if reliability_pct >= 70.0 {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::LightRed)
+        };
+        let automation_label = match processor.daemon_mode {
+            DaemonMode::Off => "Off",
+            DaemonMode::Assist => "Assist",
+            DaemonMode::Auto => "Auto",
+        };
         let header = Line::from(vec![
             Span::styled(
                 processor.name.clone(),
@@ -25,14 +38,32 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
             Span::raw(format!("| speed {:.2}", processor.speed)),
             Span::raw(" "),
             Span::raw(format!("| bias {:+}", processor.quality_bias)),
+            Span::raw(" "),
+            Span::raw(format!("| auto {}", automation_label)),
+            Span::raw(" "),
+            Span::styled(format!("| rel {reliability_pct:.1}%"), reliability_style),
         ]);
 
+        let wear_pct = (processor.wear * 100.0).min(100.0);
+        let power_draw = processor.last_power_draw();
+
         let status_line = match &processor.status {
-            ProcessorStatus::Idle => Line::from(vec![Span::styled(
-                "Idle",
-                Style::default().fg(Color::Green),
-            )]),
-            ProcessorStatus::Busy { job, .. } => {
+            ProcessorStatus::Idle => Line::from(vec![
+                Span::styled("Idle", Style::default().fg(Color::Green)),
+                Span::raw("  •  cooling "),
+                Span::raw(format!(
+                    "{}/{}",
+                    processor.cooling_level,
+                    processor.cooling_cap()
+                )),
+                Span::raw("  •  hardening "),
+                Span::raw(format!("{}", processor.hardening_level)),
+                Span::raw("  •  wear "),
+                Span::raw(format!("{wear_pct:.0}%")),
+                Span::raw("  •  draw "),
+                Span::raw(format!("{power_draw:.1} kWh")),
+            ]),
+            ProcessorStatus::Working(work) => {
                 let (remaining, total) = processor.remaining_and_total().unwrap_or((0, 1));
                 let elapsed = total.saturating_sub(remaining);
                 let remaining_secs = remaining as f64 / 1000.0;
@@ -44,9 +75,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
                     0.0
                 };
                 let progress_pct = (progress * 100.0).round() as i32;
+                let heat = processor.heat_display();
+                let heat_span = if work.overheating {
+                    Span::styled(
+                        format!("heat {heat:.2}"),
+                        Style::default().fg(Color::LightRed),
+                    )
+                } else {
+                    Span::raw(format!("heat {heat:.2}"))
+                };
                 Line::from(vec![
                     Span::styled(
-                        format!("Working on {}", job.name),
+                        format!("Working on {}", work.job.name),
                         Style::default().fg(Color::Yellow),
                     ),
                     Span::raw(" "),
@@ -55,11 +95,46 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App, game: &Game) {
                     )),
                     Span::raw(" "),
                     Span::raw(format!("remaining {remaining_secs:.1}s")),
+                    Span::raw("  •  "),
+                    heat_span,
+                    Span::raw("  •  draw "),
+                    Span::raw(format!("{power_draw:.1} kWh")),
                 ])
             }
+            ProcessorStatus::BurntOut => Line::from(vec![Span::styled(
+                "Burnt Out — press [R] to replace",
+                Style::default().fg(Color::LightRed),
+            )]),
+            ProcessorStatus::Destroyed => Line::from(vec![Span::styled(
+                "Destroyed — replace required",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            )]),
         };
 
-        items.push(ListItem::new(vec![header, status_line]));
+        let mut lines = vec![header, status_line];
+        if matches!(processor.daemon_mode, DaemonMode::Assist) {
+            if let Some(AssistSuggestion {
+                job_index,
+                eta_secs,
+                reliability,
+                heat,
+            }) = game.assist_suggestion(index)
+            {
+                if let Some(job) = game.state.jobs.get(job_index) {
+                    lines.push(Line::from(vec![
+                        Span::styled("Assist", Style::default().fg(Color::LightBlue)),
+                        Span::raw(format!(
+                            ": {} ({eta_secs:.1}s, rel {:.0}%, heat {:.2})",
+                            job.name,
+                            reliability * 100.0,
+                            heat
+                        )),
+                    ]));
+                }
+            }
+        }
+
+        items.push(ListItem::new(lines));
     }
 
     let list = List::new(items)

--- a/src/ui/store_view.rs
+++ b/src/ui/store_view.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::sim::game::Game;
+use crate::sim::game::{Game, StoreAction};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
@@ -18,9 +18,94 @@ pub fn render(frame: &mut Frame, app: &App, game: &Game) {
         .constraints([Constraint::Min(5), Constraint::Length(3)])
         .split(inner);
 
+    let processor_index = if game.state.processors.is_empty() {
+        None
+    } else {
+        Some(app.selected_processor.min(game.state.processors.len() - 1))
+    };
+
     let mut items: Vec<ListItem> = Vec::new();
     for (idx, item) in game.store_items().iter().enumerate() {
-        let cost_opt = game.item_cost(idx);
+        let processor = processor_index.and_then(|i| game.state.processors.get(i));
+        let mut status_note: Option<String> = None;
+        let cost_opt = match item.action {
+            StoreAction::UpgradeCooling => match processor {
+                Some(proc) if proc.cooling_level >= proc.cooling_cap => {
+                    status_note = Some("Cooling maxed".to_string());
+                    None
+                }
+                Some(_) => game.item_cost(idx, processor_index),
+                None => {
+                    status_note = Some("Select a processor".to_string());
+                    None
+                }
+            },
+            StoreAction::UpgradeHardening => match processor {
+                Some(proc) => {
+                    if proc.hardening_level >= 3 {
+                        status_note = Some("Hardening maxed".to_string());
+                        None
+                    } else {
+                        status_note = Some(format!("Hardening level {}", proc.hardening_level));
+                        game.item_cost(idx, processor_index)
+                    }
+                }
+                None => {
+                    status_note = Some("Select a processor".to_string());
+                    None
+                }
+            },
+            StoreAction::InstallDaemonFirmware => match processor {
+                Some(proc) if proc.daemon_unlocked => {
+                    status_note = Some("Firmware installed".to_string());
+                    None
+                }
+                Some(_) => game.item_cost(idx, processor_index),
+                None => {
+                    status_note = Some("Select a processor".to_string());
+                    None
+                }
+            },
+            StoreAction::ReplaceProcessor => match processor {
+                Some(proc) if !proc.is_functional() => game.item_cost(idx, processor_index),
+                Some(_) => {
+                    status_note = Some("Unit is operational".to_string());
+                    None
+                }
+                None => {
+                    status_note = Some("Select a processor".to_string());
+                    None
+                }
+            },
+            StoreAction::ReplaceModel => match processor {
+                Some(proc) => {
+                    let offline = game
+                        .state
+                        .processors
+                        .iter()
+                        .filter(|p| p.name == proc.name && !p.is_functional())
+                        .count();
+                    if offline == 0 {
+                        status_note = Some("Fleet operational".to_string());
+                        None
+                    } else {
+                        status_note = Some(format!("{offline} unit(s) offline"));
+                        game.item_cost(idx, processor_index)
+                    }
+                }
+                None => {
+                    status_note = Some("Select a processor".to_string());
+                    None
+                }
+            },
+            StoreAction::ApplyThermalPaste => {
+                if game.thermal_paste_active() {
+                    status_note = Some("Active this cycle".to_string());
+                }
+                game.item_cost(idx, processor_index)
+            }
+            _ => game.item_cost(idx, processor_index),
+        };
         let purchased = game.store_purchases(idx).unwrap_or(0);
         let affordable = cost_opt
             .map(|cost| game.state.credits >= cost)
@@ -38,10 +123,13 @@ pub fn render(frame: &mut Frame, app: &App, game: &Game) {
         line.push(Span::styled(item.name, name_style));
         match cost_opt {
             Some(cost) => line.push(Span::raw(format!("  [{} cr]", cost))),
-            None => line.push(Span::styled(
-                "  [SOLD OUT]",
-                Style::default().fg(Color::DarkGray),
-            )),
+            None => {
+                let label = status_note.as_deref().unwrap_or("Unavailable");
+                line.push(Span::styled(
+                    format!("  [{}]", label),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
         }
         if purchased > 0 {
             if let Some(max) = item.max_purchases {
@@ -52,7 +140,28 @@ pub fn render(frame: &mut Frame, app: &App, game: &Game) {
         } else if let Some(max) = item.max_purchases {
             line.push(Span::raw(format!("  (limit {max})")));
         }
-        let detail = Line::from(item.description);
+        let mut detail_spans = vec![Span::raw(item.description)];
+        if let Some(proc) = processor {
+            if matches!(
+                item.action,
+                StoreAction::UpgradeCooling
+                    | StoreAction::UpgradeHardening
+                    | StoreAction::InstallDaemonFirmware
+                    | StoreAction::ReplaceProcessor
+                    | StoreAction::ReplaceModel
+            ) {
+                detail_spans.push(Span::raw(" • Target: "));
+                detail_spans.push(Span::styled(
+                    proc.name.clone(),
+                    Style::default().fg(Color::LightCyan),
+                ));
+            }
+        }
+        if let Some(note) = status_note {
+            detail_spans.push(Span::raw(" • "));
+            detail_spans.push(Span::styled(note, Style::default().fg(Color::LightMagenta)));
+        }
+        let detail = Line::from(detail_spans);
         let list_item = ListItem::new(vec![Line::from(line), detail]);
         items.push(list_item);
     }


### PR DESCRIPTION
## Summary
- add a helper that assigns the highlighted processor's assist suggestion and surfaces friendly messages when unavailable
- let Enter/A trigger assist pickup when no job is queued, keeping processor interactions smooth
- cover the assist handoff path with a unit test

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68cce417fc38832ea86bbe722b1d6366